### PR TITLE
Minor Improvements

### DIFF
--- a/gfx_perp_sdk/agnostic/EventQueue.py
+++ b/gfx_perp_sdk/agnostic/EventQueue.py
@@ -9,7 +9,7 @@ from gfx_perp_sdk.agnostic.Slabs import combine_u64_to_u128, CallbackInfo
 class FillEvent:
     tag: int
     takerSide: int
-    makerOrderId: int
+    makerOrderId: str
     quoteSize: int
     baseSize: int
     LEN: int = 40
@@ -92,6 +92,7 @@ class EventQueue:
                     '<B6xQQQQ', event_chunk[1: FillEvent.LEN])             
                 makerOrderId = combine_u64_to_u128(
                     makerOrderIdUp, makerOrderIdDown)
+                makerOrderId = str(makerOrderId)
                 fill_event = FillEvent(
                     tag, takerSide, makerOrderId, quoteSize, baseSize)
 

--- a/gfx_perp_sdk/perp.py
+++ b/gfx_perp_sdk/perp.py
@@ -12,16 +12,6 @@ class NETWORK_TYPE(Enum):
     devnet = "devnet"
     mainnet = "mainnet"
 
-class TradeSide(Enum):
-    buy = "buy"
-    sell = "sell"
-
-class OrderType(Enum):
-    limit = "limit"
-    market = "market"
-    immediateOrCancel = "immediateOrCancel"
-    postOnly = "postOnly"
-
 class Product_Type(TypedDict):
     name: str
     PRODUCT_ID: PublicKey

--- a/gfx_perp_sdk/trader.py
+++ b/gfx_perp_sdk/trader.py
@@ -335,8 +335,8 @@ class Trader(Perp):
     async def subscribe_trader_positions(self, product: Product, on_fill_out_change):
         await product.subscribe_to_trades(self.trgKey, on_fill_out_change)
     
-    async def subscribe_to_trader_risk_group(self, on_trader_state_change, change_param: str):
-        wss = self.connection._provider.endpoint_uri.replace("http", "ws")
+    async def subscribe_to_trader_risk_group(self, on_trader_state_change, subscription_type: utils.TraderSubscriptionType):
+        wss = self.connection._provider.endpoint_uri.replace("https", "ws")
         async with connect(wss) as solana_websocket:
             solana_websocket: SolanaWsClientProtocol
             await solana_websocket.account_subscribe(pubkey=self.trgKey, commitment="processed", encoding="base64")
@@ -351,7 +351,7 @@ class Trader(Perp):
                         r1 = msg[0].result.value.data
                         decoded = r1[8:]
                         currTrg: TraderRiskGroup = TraderRiskGroup.from_bytes(decoded)
-                        trg_diffs = utils.compare_trader_risk_groups(prevTrg, currTrg, change_param)
+                        trg_diffs = utils.compare_trader_risk_groups(prevTrg, currTrg, subscription_type)
                         if trg_diffs != {}:
                             on_trader_state_change(trg_diffs)
                         prevTrg = currTrg
@@ -430,7 +430,7 @@ class Trader(Perp):
         return positions
     
     async def subscribe_to_token_balance_change(self, callback_func):
-        wss = self.connection._provider.endpoint_uri.replace("http", "ws")
+        wss = self.connection._provider.endpoint_uri.replace("https", "ws")
         async with connect(wss) as solana_websocket:
             solana_websocket: SolanaWsClientProtocol
             await solana_websocket.account_subscribe(pubkey=self.userTokenAccount, commitment="processed", encoding="base64")

--- a/test_perp.py
+++ b/test_perp.py
@@ -182,9 +182,7 @@ async def test_trader_new_order_multiple():
         23456
         )
     response = utils.send_solana_transaction(rpc_client, keyp, ix1[0] + ix2[0], ix1[1])
-    print(response)
-    status = utils.get_transaction_status(connection=rpc_client, raw_sigs=[response])
-    print("\n status:", status)
+    print("\n response:", response)
     assert response != None
 
 # @pytest.mark.asyncio


### PR DESCRIPTION
Subscription Type for trader params is changed to enum TraderSubscriptionType instead of string.

Callback function of subscribe_to_asks/bids will now give latest full bid array, new asks/bids and also removed asks/bids

The commitment of the websocket subscriptions is now changed to “processed” instead of “confirmed” with which we can see significant improvement in response speed

get_order_details_by_order_id will. now return the callback_id of the order

makerOrderId in FillEvents is now made string instead of integer value