### PR TITLE
fix: enable users to initialize perp with wallet address only

### DIFF
--- a/gfx_perp_sdk/perp.py
+++ b/gfx_perp_sdk/perp.py
@@ -42,16 +42,23 @@ class Perp:
     mpgBytes: bytes
     connection: Client
     program: str #TODO: Change
-    wallet: Keypair 
+    wallet: Keypair
+    wallet_public_key: PublicKey
     networkType: NETWORK_TYPE
     ADDRESSES: ConstantIDs
 
     def __init__(self, connection: Client, 
       network_type: NETWORK_TYPE, 
-      wallet: Keypair, 
+      wallet: Keypair = None,
       mpg: MarketProductGroup = None, 
-      mpgBytes: bytes = None):
+      mpgBytes: bytes = None,
+      wallet_address: PublicKey = None):
+      if wallet is None and wallet_address is None:
+          raise ValueError("Either wallet or wallet_address must be provided.")
+      elif wallet is not None and wallet_address is not None:
+          raise ValueError("Provide either wallet or wallet_address, not both.")
       self.wallet = wallet
+      self.wallet_public_key = wallet.pubkey() if wallet is not None else wallet_address
       self.connection = connection
       self.networkType = network_type
       if self.networkType == "mainnet":

--- a/gfx_perp_sdk/product.py
+++ b/gfx_perp_sdk/product.py
@@ -32,7 +32,8 @@ class Product(Perp):
         perp.networkType, 
         perp.wallet, 
         perp.marketProductGroup, 
-        perp.mpgBytes)
+        perp.mpgBytes,
+        perp.wallet_public_key)
 
     def init_by_index(self, index: int):
         products = None


### PR DESCRIPTION
This enables users to do things like fetching collateral and positions without needing the wallet keypair. Functions which require wallet e.g deposit_funds_ix in the Trader class will raise an error if the perp class was not initialised with the wallet keypair.