### PR TITLE
fix: remove check that doesn't allow both wallet and wallet_address to be provided

### DIFF
--- a/gfx_perp_sdk/perp.py
+++ b/gfx_perp_sdk/perp.py
@@ -55,8 +55,6 @@ class Perp:
       wallet_address: PublicKey = None):
       if wallet is None and wallet_address is None:
           raise ValueError("Either wallet or wallet_address must be provided.")
-      elif wallet is not None and wallet_address is not None:
-          raise ValueError("Provide either wallet or wallet_address, not both.")
       self.wallet = wallet
       self.wallet_public_key = wallet.pubkey() if wallet is not None else wallet_address
       self.connection = connection


### PR DESCRIPTION
This check causes errors because after perps is initialized wallet_public_key is set and this is used in the Trader and Product classes to init perps, so they will always throw an error since by the time they are called perps has been initialized and both wallet and wallet_public_key are available.